### PR TITLE
Give DefaultDrawer options to set output video format and FPS

### DIFF
--- a/src/ethoscope/drawers/drawers.py
+++ b/src/ethoscope/drawers/drawers.py
@@ -108,7 +108,7 @@ class NullDrawer(BaseDrawer):
 
 
 class DefaultDrawer(BaseDrawer):
-    def __init__(self, video_out= None, draw_frames=False):
+    def __init__(self, video_out= None, draw_frames=False, video_out_fourcc="DIVX", video_out_fps=2):
         """
         The default drawer. It draws ellipses on the detected objects and polygons around ROIs. When an "interaction"
         see :class:`~ethoscope.stimulators.stimulators.BaseInteractor` happens within a ROI,
@@ -119,7 +119,7 @@ class DefaultDrawer(BaseDrawer):
         :param draw_frames: Whether frames should be displayed on the screen (a new window will be created).
         :type draw_frames: bool
         """
-        super(DefaultDrawer,self).__init__(video_out=video_out, draw_frames=draw_frames)
+        super(DefaultDrawer,self).__init__(video_out=video_out, draw_frames=draw_frames, video_out_fourcc=video_out_fourcc, video_out_fps=video_out_fps)
 
     def _annotate_frame(self,img, positions, tracking_units):
         if img is None:


### PR DESCRIPTION
The base class `ethoscope.drawers.BaseDrawer` has init parameters to set the output video format and frames per second, but the derived class `ethoscope.drawers.DefaultDrawer` doesn't.  This Pull Request just adds these options to DefaultDrawer.