### PR TITLE
MySQL Data base dump  

### DIFF
--- a/node_src/ethoscope_node/test/test_mysql_backup.py
+++ b/node_src/ethoscope_node/test/test_mysql_backup.py
@@ -1,0 +1,24 @@
+from nose.tools import assert_equal
+from ethoscope_node.utils.mysql_db_writer import MySQLdbCSVWriter
+#from ethoscope_node.utils.mysql_backup import DBNotReadyError
+import os
+import logging
+import traceback
+
+def TestMySQLDump():
+
+    try:
+
+        mirror = MySQLdbCSVWriter("/Users/phrfp/Software/anaconda2/envs/ethoscope/home/tmp",
+                        remote_db_name="test_etho_db",
+                        remote_host="localhost",
+                        remote_pass="",
+                        remote_user="root")
+
+
+        mirror.update_roi_tables()
+
+
+    except Exception as e:
+        print e
+        logging.error(traceback.format_exc(e))

--- a/node_src/ethoscope_node/utils/mysql_backup.py
+++ b/node_src/ethoscope_node/utils/mysql_backup.py
@@ -19,19 +19,15 @@ class MySQLdbToSQlite(object):
                             remote_pass="ethoscope",
                             overwrite=False):
         """
-
         A class to backup remote psv MySQL data base into a local sqlite3 one.
         The name of the static (not updated during run) and the dynamic tables is hardcoded.
         The `update_roi_tables` method will fetch only the new datapoint at each run.
-
         :param dst_path: where to save the data (expect a `.db` file)
         :param remote_db_name: the name of the remote database
         :param remote_host: the ip of the database
         :param remote_user: the user name for the remote database
         :param remote_pass: teh password for the remote database
         :param overwrite: whether the destination file should be overwritten. If False, data are appended to it
-
-
         """
 
         self._remote_host = remote_host
@@ -135,7 +131,6 @@ class MySQLdbToSQlite(object):
     def update_roi_tables(self):
         """
         Fetch new ROI tables and new data points in the remote and use them to update local db
-
         :return:
         """
 
@@ -288,5 +283,3 @@ class MySQLdbToSQlite(object):
             command = "INSERT INTO %s (id,t,img) VALUES(?,?,?);" % table_name
             dst_cur.execute(command, [id,t,sqlite3.Binary(img)])
             dst.commit()
-
-

--- a/node_src/ethoscope_node/utils/mysql_db_writer.py
+++ b/node_src/ethoscope_node/utils/mysql_db_writer.py
@@ -1,0 +1,89 @@
+__author__ = 'ryanfpage'
+
+import MySQLdb
+import os
+import logging
+import traceback
+
+
+class MySQLdbCSVWriter(object):
+
+    def __init__(self, dst_path,
+                            remote_db_name="ethoscope_db",
+                            remote_host="localhost",
+                            remote_user="ethoscope",
+                            remote_pass="ethoscope",
+                            overwrite=True):
+        """
+
+        A class to dump the current data base into a pandas data frame. This is going to be intially desigend and
+        tested so that it runs with the MySQL server running locally and not remotly.
+
+
+        :param db_name: the name of the database running locally.
+        :param host: the ip of the database - localhost will be fully test remote testing to follow
+        :param user: the user name for the database
+        :param pass: the password for the database
+        :param overwrite: whether the destination file should be overwritten. If False, data are appended to it
+
+
+        """
+        try:
+            self._remote_host = remote_host
+            self._remote_user = remote_user
+            self._remote_pass = remote_pass
+            self._remote_db_name = remote_db_name
+
+            self._dst_path=dst_path
+
+            self._csv_file_name = self._dst_path+"/"+self._remote_db_name + ".csv"
+            print ("Filename:", self._csv_file_name)
+
+            # we remove file and create dir, if needed
+
+            if overwrite:
+                logging.info("Trying to remove old database")
+                try:
+                    os.remove(self._csv_file_name)
+                    logging.info("Success")
+                except OSError as e:
+                    logging.warning(e)
+                    pass
+
+
+
+        except Exception as e:
+            raise
+
+    def update_roi_tables(self):
+        """
+        Fetch new ROI tables and new data points in the remote and use them to update local db
+
+        :return:
+        """
+
+        src = MySQLdb.connect(host=self._remote_host, user=self._remote_user,
+                                         passwd=self._remote_pass, db=self._remote_db_name)
+
+
+
+
+        command = "SELECT roi_idx FROM ROI_MAP"
+        cur = src.cursor()
+        cur.execute(command)
+        rois_in_src = set([c[0] for c in cur])
+        for i in rois_in_src :
+            print "ROIs: ", i
+            self._update_one_roi_table("ROI_%i" % i, i, src)
+
+    def _update_one_roi_table(self, table_name, roi_num,src):
+        src_cur = src.cursor()
+        src_command = "SELECT * FROM %s" % (table_name)
+        src_cur.execute(src_command)
+
+        for sc in src_cur:
+            with open(self._csv_file_name,"a") as f:
+                row = "\t".join(["{0}".format(val) for val in sc])
+                row += "\t"+str(roi_num)
+                f.write(row)
+                f.write("\n")

--- a/node_src/ethoscope_node/utils/mysql_db_writer.py
+++ b/node_src/ethoscope_node/utils/mysql_db_writer.py
@@ -16,14 +16,14 @@ class MySQLdbCSVWriter(object):
                             overwrite=True):
         """
 
-        A class to dump the current data base into a pandas data frame. This is going to be intially desigend and
-        tested so that it runs with the MySQL server running locally and not remotly.
+        A class to dump the current data base into a csv file. Connects to MySQL server and pulls the data in the
+        ROI tables out, writing them to a txt file. The columns are tab formatted.
 
 
-        :param db_name: the name of the database running locally.
-        :param host: the ip of the database - localhost will be fully test remote testing to follow
-        :param user: the user name for the database
-        :param pass: the password for the database
+        :param remote_db_name: the name of the database running locally.
+        :param remote_host: the ip of the database - localhost will be fully test remote testing to follow
+        :param remote_user: the user name for the database
+        :param remote_pass: the password for the database
         :param overwrite: whether the destination file should be overwritten. If False, data are appended to it
 
 
@@ -36,10 +36,10 @@ class MySQLdbCSVWriter(object):
 
             self._dst_path=dst_path
 
-            self._csv_file_name = self._dst_path+"/"+self._remote_db_name + ".csv"
-            print ("Filename:", self._csv_file_name)
+            self._csv_file_name = self._dst_path+"/"+self._remote_db_name + ".txt"
+            #print ("Filename:", self._csv_file_name)
 
-            # we remove file and create dir, if needed
+            #TODO add dir exists check and create if needed
 
             if overwrite:
                 logging.info("Trying to remove old database")
@@ -80,7 +80,7 @@ class MySQLdbCSVWriter(object):
         src_cur = src.cursor()
         src_command = "SELECT * FROM %s" % (table_name)
         src_cur.execute(src_command)
-
+        #TODO add column names to first row
         for sc in src_cur:
             with open(self._csv_file_name,"a") as f:
                 row = "\t".join(["{0}".format(val) for val in sc])


### PR DESCRIPTION
The MySQLdbCSVWriter class connects to the MySQL data base where the ethoscope is sending data, this is configured in the constructor arguments, and creates a text file of the ROI tables in a single file. The format is tab spaced, with an added column indicating which ROI the data belongs to.

There is a test in the test dir (node_src/ethoscope_node/test) where I have started developing a unit test for the class. At the moment all it does is check if exceptions are thrown and does not do that correctly. If you run it and pass the db setup parameters it will generate a txt file, which I have checked by eye is correct.

Here is a sample of the output:

1	8000	291	34	5	3	117	-280	0	0	0      2
2	8050	291	34	4	3	56	-2605	0	0	2
3	8100	291	34	4	3	18	-2625	0	0	2
4	8150	291	34	4	3	18	-2622	0	0	2
5	8200	291	34	5	4	166	-2709	0	0	2
6	8250	291	34	7	3	16	-2645	0	0	2
7	8300	291	34	7	3	16	-2748	0	0	2
8	8350	290	34	4	4	166	-2539	0	0	2
9	8400	290	34	3	3	162	-2576	0	0	2
10	8450	290	34	4	3	162	-2595	0	0	2