### PR TITLE
Remove CherryPy

### DIFF
--- a/node_src/scripts/server.py
+++ b/node_src/scripts/server.py
@@ -334,7 +334,7 @@ if __name__ == '__main__':
         device_scanner = DeviceScanner(LOCAL_IP, results_dir=RESULTS_DIR)
         #device_scanner = DeviceScanner( results_dir=RESULTS_DIR)
         device_scanner.start()
-        run(app, host='0.0.0.0', port=PORT, debug=DEBUG, server='cherrypy')
+        run(app, host='0.0.0.0', port=PORT, debug=DEBUG)
 
     except KeyboardInterrupt:
         logging.info("Stopping server cleanly")

--- a/scripts/ethoscope_updater/update_server.py
+++ b/scripts/ethoscope_updater/update_server.py
@@ -242,7 +242,7 @@ if __name__ == '__main__':
 
 
     try:
-        run(app, host='0.0.0.0', port=port, debug=debug, server='cherrypy')
+        run(app, host='0.0.0.0', port=port, debug=debug)
 
     except KeyboardInterrupt:
         logging.info("Stopping update server cleanly")

--- a/src/scripts/device_server.py
+++ b/src/scripts/device_server.py
@@ -224,7 +224,7 @@ if __name__ == '__main__':
         control.start()
 
     try:
-        run(api, host='0.0.0.0', port=port, server='cherrypy',debug=option_dict["debug"])
+        run(api, host='0.0.0.0', port=port, debug=option_dict["debug"])
     except Exception as e:
         logging.error(e)
         close(1)


### PR DESCRIPTION
The latest version of CherryPy is not compatible with the latest version of Bottle. See https://github.com/bottlepy/bottle/issues/975.  This Pull Request takes out the mention of CherryPy so that Bottle uses its own default server.