### PR TITLE
Limit network scan to stop thread error

### DIFF
--- a/node_src/ethoscope_node/utils/device_scanner.py
+++ b/node_src/ethoscope_node/utils/device_scanner.py
@@ -59,7 +59,10 @@ class DeviceScanner(Thread):
         self._ip_range = ip_range
         self._use_scapy = _use_scapy
 
-        for ip in self._subnet_ips(local_ip, (6,254)):
+        # N.B. The ip range has been limited to 6-30 here temporarily because the system runs out of
+        # threads for each Device. This means that if your ethoscope happens to have a subnet IP
+        # greater than 30 it will not be found. TODO - come up with a better solution.
+        for ip in self._subnet_ips(local_ip, (6,30)):
             d =  Device(ip, device_refresh_period, results_dir=results_dir)
             d.start()
             self._devices.append(d)


### PR DESCRIPTION
**NOTE:** This is a short term hack to get things working until a long term solution can be found.

A thread is created for every subnet IP that gets scanned (6-254, so 248 threads), and at some point it throws an exception because the system limit of how many threads can be created gets hit.  This temporarily limits the network scan to the subnet IPs 6 to 30.

This has the consequence that **if your Ethoscope has an subnet IP address greater than 30 it will not be found** by the node.