### PR TITLE
Fix download link on Firefox

### DIFF
--- a/node_src/static/js/controllers/ethoscopeController.js
+++ b/node_src/static/js/controllers/ethoscopeController.js
@@ -171,7 +171,11 @@ app.controller('ethoscopeController', function($scope, $http, $routeParams, $int
         };
 
         $scope.ethoscope.downloaddb = function(){
-            var downloadLink = angular.element('<a href="/downloaddb/'+device_id+'?ip='+$scope.device.ip+'"></a>');
+            var downloadLink=$("#downloaddbHiddenLink")
+            downloadLink.attr({
+                href: "/downloaddb/"+device_id+"?ip="+$scope.device.ip,
+                target: "_blank"
+                })
             downloadLink[0].click();
         };
 

--- a/node_src/static/pages/ethoscope.html
+++ b/node_src/static/pages/ethoscope.html
@@ -141,6 +141,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         <button type="button" class="btn btn-primary" ng-click="ethoscope.downloaddb()" data-dismiss="modal">Download</button>
+        <a id="downloaddbHiddenLink"></a> <!-- Firefox requires a link to be in the DOM to do "click()" on it -->
       </div>
     </div>
   </div>


### PR DESCRIPTION
Firefox requires a link to be in the DOM for "click()" to work on it, so dynamically creating a link with angular doesn't work. This commit now dynamically changes the address of a link "hidden" (just has no content) in the DOM, and then calls "click()" on it.

Tested with Firefox, Chrome and Internet Explorer on Windows 10; and Safari in OS X Sierra. Works fine (mildly annoying new window briefly shows up though).

Microsoft Edge doesn't resolve the multicast-DNS hostname, but if you use the IP address directly then file download works.  Fixing mDNS for Edge is a separate issue not covered here.