### PR TITLE
Always allow downloads

### DIFF
--- a/node_src/static/pages/ethoscope.html
+++ b/node_src/static/pages/ethoscope.html
@@ -68,7 +68,7 @@
             <button class="btn btn-info disable" ng-if="device.status == 'stopping'" ng-click="ethoscope.alert('Please wait, system is stopping')">Stopping</button>
             <button class="btn btn-danger disable" ng-if="device.status == 'initialising'"  ng-click="ethoscope.alert('Please wait, system is starting')">Starting</button>
 
-            <button class="btn btn-info" ng-if="device.status == 'stopped'"  data-toggle="modal" data-target="#downloadResultsModal">Download results</button>
+            <button class="btn btn-info" data-toggle="modal" data-target="#downloadResultsModal">Download results</button>
         <!--<a href="/#/more/browse" class="btn btn-info">Download Data</a>-->
             <button class="btn btn-info" ng-click="ethoscope.log()">Log</button>
 


### PR DESCRIPTION
Keeps the "Download results" button always available, so that data can be downloaded while still running without disturbing the run.

Note that you can hit an error if there is no tracking data yet (see #30).

Fixes #19.