### PR TITLE
Fix updater (rymapt_test)

### DIFF
--- a/scripts/ethoscope_updater/update_server.py
+++ b/scripts/ethoscope_updater/update_server.py
@@ -225,13 +225,14 @@ if __name__ == '__main__':
         bare_repo_updater = updater.BareRepoUpdater(bare_repo)
         is_node = True
         device_id = "Node"
+        LOCAL_IP = get_local_ip(option_dict["router_ip"], is_node=is_node)
 
     else:
         bare_repo_updater = None
         is_node = False
         device_id = get_machine_info(MACHINE_ID_FILE)
+        LOCAL_IP = "127.0.0.1"
 
-    LOCAL_IP = get_local_ip(option_dict["router_ip"], is_node=is_node)
     try:
         WWW_IP = get_internet_ip()
     except Exception as e:

--- a/scripts/ethoscope_updater/update_server.py
+++ b/scripts/ethoscope_updater/update_server.py
@@ -74,6 +74,7 @@ def device(action,id):
                 reload_node_daemon()
             else:
                 reload_device_daemon()
+                reload_node_daemon()
         else:
             raise UnexpectedAction()
 


### PR DESCRIPTION
Minor changes to the updater service so that it can be used with ethoscopes that run a node and device code on the same unit.