### PR TITLE
Add set time from browser

### DIFF
--- a/node_src/ethoscope_node/utils/device_scanner.py
+++ b/node_src/ethoscope_node/utils/device_scanner.py
@@ -198,7 +198,8 @@ class Device(Thread):
                                      "start_record": ["stopped"],
                                      "stop": ["running", "recording"],
                                      "poweroff": ["stopped"],
-                                     "not_in_use": []}
+                                     "not_in_use": [],
+                                     "settime": ["stopped"]}
 
     def __init__(self,ip, refresh_period= 2, port = 9000, results_dir="/ethoscope_results"):
         self._results_dir = results_dir

--- a/node_src/ethoscope_node/utils/device_scanner.py
+++ b/node_src/ethoscope_node/utils/device_scanner.py
@@ -217,7 +217,7 @@ class Device(Thread):
         last_refresh = 0
         while self._is_active:
             time.sleep(.2)
-            if time.time() - last_refresh > self._refresh_period:
+            if abs(time.time() - last_refresh) > self._refresh_period:
 
                 if not self._skip_scanning:
                     self._update_info()

--- a/node_src/static/js/controllers/ethoscopeController.js
+++ b/node_src/static/js/controllers/ethoscopeController.js
@@ -175,6 +175,17 @@ app.controller('ethoscopeController', function($scope, $http, $routeParams, $int
             downloadLink[0].click();
         };
 
+        $scope.ethoscope.set_time_from_browser = function(){
+            var date = new Date();
+            $http.post('/device/'+device_id+'/controls/settime',
+                    data={
+                        "month": date.getUTCMonth()+1, // I want it 1..12, but getUTCMonth() is 0..11
+                        "date": date.getUTCDate(),
+                        "hours": date.getUTCHours(),
+                        "minutes": date.getUTCMinutes()
+                    });
+        };
+
         $scope.ethoscope.log = function(){
             var log_file_path = ''
             if ($scope.showLog == false){
@@ -245,6 +256,8 @@ app.controller('ethoscopeController', function($scope, $http, $routeParams, $int
                 if("current_timestamp" in data){
                     $scope.device_timestamp = new Date(data.current_timestamp*1000);
                     $scope.device_datetime = $scope.device_timestamp.toUTCString();
+                    browser_time = new Date();
+                    $scope.browser_delta_t_min = (browser_time - $scope.device_timestamp) / 1000 / 60;
                     $http.get('/node/timestamp').success(function(data_node){
                         node_t = data_node.timestamp;
                         node_time = new Date(node_t*1000);

--- a/node_src/static/pages/ethoscope.html
+++ b/node_src/static/pages/ethoscope.html
@@ -9,6 +9,11 @@
         <h2 id="dt_warning"><span class="fa fa-warning"></span> There is more than 5min difference between node and this device!!</h2>
         </div>
 
+        <div ng-if="browser_delta_t_min > 5">
+           <h2 id="dt_warning"><span class="fa fa-warning"></span>There is more than 5min difference between this device and your browser!!</h2>
+           <button ng-if="device.status == 'stopped'" class="btn btn-danger" ng-click="ethoscope.set_time_from_browser()">Set device time from browser</button>
+           <div ng-if="device.status != 'stopped'"><h3>The device time can be set from the browser only when the device is stopped</h3></div>
+        </div>
 
 
 

--- a/src/scripts/device_server.py
+++ b/src/scripts/device_server.py
@@ -128,6 +128,12 @@ def controls(id, action):
 
         control.start()
         return info(id)
+    elif action == 'settime':
+        # TODO check the status of ntp and maybe refuse to set the time if ntp is working
+        timeString="%02d%02d%02d%02d" % (request.json["month"],request.json["date"],request.json["hours"],request.json["minutes"])
+        logging.warning("Requested that the time be set to "+str(timeString))
+        call( ["date", "--utc", timeString] )
+        return info(id)
     else:
         raise Exception("No such action: %s" % action)
 


### PR DESCRIPTION
Checks the device time against the browser time, and if the difference is greater than 5 minutes displays a warning and a button that can set the device time from the browser time.

This is designed for situations where NTP is not working/available for whatever reason, e.g. closed networks where no computer has an internet connection. The assumption is that the browser is run from a computer that has recently connected to the internet and hence has accurate time.