### PR TITLE
Remove check on the node IP address

### DIFF
--- a/node_src/scripts/server.py
+++ b/node_src/scripts/server.py
@@ -330,7 +330,6 @@ if __name__ == '__main__':
     DEBUG = option_dict["debug"]
     RESULTS_DIR = option_dict["results_dir"]
     max_address = 255 if DEBUG else 5
-    LOCAL_IP = get_local_ip(option_dict["subnet_ip"], max_node_subnet_address=max_address, localhost=option_dict["local"])
 
     try:
         WWW_IP = get_internet_ip()
@@ -342,8 +341,7 @@ if __name__ == '__main__':
     tmp_imgs_dir = tempfile.mkdtemp(prefix="ethoscope_node_imgs")
     device_scanner = None
     try:
-        device_scanner = DeviceScanner(LOCAL_IP, results_dir=RESULTS_DIR)
-        #device_scanner = DeviceScanner( results_dir=RESULTS_DIR)
+        device_scanner = DeviceScanner(results_dir=RESULTS_DIR)
         device_scanner.start()
         run(app, host='0.0.0.0', port=PORT, debug=DEBUG)
 


### PR DESCRIPTION
The node currently won't start because the IP address doesn't match the "expected" subnet hardcoded in (you can change the subnet with the `-r` argument but the ethoscope_node.service doesn't do this).

The IP address is only needed to find out the subnet range to scan, but now that we use zeroconf to find devices this is completely unnecessary.  So this takes out the `get_local_ip` call where the check against the "expected" subnet is made.