### PR TITLE
Add conditions monitor

### DIFF
--- a/src/ethoscope/core/conditions_monitor.py
+++ b/src/ethoscope/core/conditions_monitor.py
@@ -33,6 +33,21 @@ class ConditionVariable(object):
     def description(self):
         return self._description
 
+class ConditionVariableFunction(object):
+    """
+    Similar to ConditionVariable except that it takes a function to generate the value.
+    """
+    def __init__(self, function, name, description = None):
+        self._function = function
+        self._name = name
+        self._description = description
+    def value(self):
+        return self._function()
+    def name(self):
+        return self._name
+    def description(self):
+        return self._description
+
 class ConditionsProcess(multiprocessing.Process):
     """
     The portion of ConditionsMonitor that runs in a different process. This should never be invoked

--- a/src/ethoscope/core/conditions_monitor.py
+++ b/src/ethoscope/core/conditions_monitor.py
@@ -83,7 +83,17 @@ class ConditionsProcess(multiprocessing.Process):
                                      sqlalchemy.Column('id', sqlalchemy.Integer, sqlalchemy.Sequence('entry_id_seq'), primary_key=True),
                                      sqlalchemy.Column('t', sqlalchemy.Integer ) )
             for variable in self._conditionVariables:
-                table.append_column( sqlalchemy.Column( variable.name(), sqlalchemy.Integer) )
+                # Get one value to see what type it is
+                valueType = sqlalchemy.Integer
+                try:
+                    value = variable.value()
+                    if type(value) is float: valueType = sqlalchemy.Float
+                    elif type(value) is int: valueType = sqlalchemy.Integer
+                    else:
+                        logging.warning("Unable to determine database type for '"+str(type(value))+"', assuming integer")
+                except Exception as error:
+                    logging.error("Unable to determine database type for '"+variable.name()+"' "+str(error))
+                table.append_column( sqlalchemy.Column( variable.name(), valueType) )
             metadata.create_all(self._sqlalchemy_engine)
 
             while self._keepRunning.value:

--- a/src/ethoscope/core/conditions_monitor.py
+++ b/src/ethoscope/core/conditions_monitor.py
@@ -1,0 +1,157 @@
+__author__ = "grimes"
+
+import multiprocessing
+import logging
+import time
+import sqlalchemy
+
+class ConditionVariable(object):
+    """
+    A convenience class for code to make variables available to the ConditionMonitor. Code would create an
+    instance of ConditionVariable by passing it a multiprocessing.Value and name for the variable, and passing
+    the new ConditionVariable instance to ConditionsMonitor. When the variable changes they should modify
+    their copy of the multiprocessing.Value directly. I.e. the code monitoring the condition would keep a
+    reference to the multiprocessing.Value and forget about the ConditionVariable once it was passed to
+    ConditionsMonitor.
+
+    You don't need to use this class, as long as ConditionsMonitor receives an object with "value()" and
+    "name()" methods, and that the "value()" method is multiprocessing safe.
+    """
+    def __init__(self, value, name, description = None):
+        self._variable = value
+        self._name = name
+        self._description = description
+
+        # required for the database
+        self.header_name = name
+        self.sql_data_type = "SMALLINT"
+        self.functional_type = "not set yet"
+    def value(self):
+        return self._variable.value
+    def name(self):
+        return self._name
+    def description(self):
+        return self._description
+
+class ConditionsProcess(multiprocessing.Process):
+    """
+    The portion of ConditionsMonitor that runs in a different process. This should never be invoked
+    directly, only through ConditionsMonitor.
+    """
+    def __init__(self, keepRunning, updatePeriodSeconds, pollingCondition, conditionVariables):
+        super(ConditionsProcess,self).__init__()
+        self._keepRunning = keepRunning
+        self._updatePeriodSeconds = updatePeriodSeconds
+        self._pollingCondition = pollingCondition
+        self._sqlalchemy_engine = None
+        self._tableName = "CONDITIONS"
+        self._conditionVariables = conditionVariables
+        self._isRunning = multiprocessing.Value('b', False)
+        self._timeOffset = multiprocessing.Value('d', 0) # Needs to be double, I get numerical errors with a single float
+        self._timeCoefficient = multiprocessing.Value('f', 1000) # default to using time in milliseconds
+
+    def set_writer(self,sqlalchemy_engine):
+        if self._isRunning.value:
+            raise Exception("Unable to change writer while running")
+
+        self._sqlalchemy_engine = sqlalchemy_engine
+
+    def run(self):
+        logging.info("ConditionsMonitor starting")
+        self._isRunning.value = True
+
+        try:
+            # Make sure the database has the table in place
+            metadata = sqlalchemy.MetaData()
+            table = sqlalchemy.Table(self._tableName,
+                                     metadata,
+                                     sqlalchemy.Column('id', sqlalchemy.Integer, sqlalchemy.Sequence('entry_id_seq'), primary_key=True),
+                                     sqlalchemy.Column('t', sqlalchemy.Integer ) )
+            for variable in self._conditionVariables:
+                table.append_column( sqlalchemy.Column( variable.name(), sqlalchemy.Integer) )
+            metadata.create_all(self._sqlalchemy_engine)
+
+            while self._keepRunning.value:
+                results = {"t": int( (time.time() - self._timeOffset.value)*self._timeCoefficient.value )}
+                for variable in self._conditionVariables:
+                    try:
+                        name = variable.name()
+                        value = variable.value()
+                        results[name] = value
+                    except Exception as error:
+                        try:
+                            name = variable.name()
+                        except:
+                            name = "<exception getting name>"
+                        logging.error("Condition variable '"+name+"' could not be logged because it produced the exception: "+str(error))
+
+                connection = self._sqlalchemy_engine.connect()
+                connection.execute(table.insert(), [results] )
+
+                with self._pollingCondition:
+                    self._pollingCondition.wait(self._updatePeriodSeconds.value)
+        finally:
+            logging.info("ConditionsMonitor stopping")
+            self._isRunning.value = False
+
+class ConditionsMonitor(object):
+    """
+    Class that monitors condition variables (e.g. light, temperature etcetera) and writes them to the
+    database.
+
+    Underneath it starts another process to do the work, but all interaction should be through this class.
+    """
+    def __init__(self, conditionVariables):
+        self._keepRunning = multiprocessing.Value('b',True)
+        self._updatePeriodSeconds = multiprocessing.Value('f',30)
+        self._pollingCondition = multiprocessing.Condition()
+        self._process = ConditionsProcess(self._keepRunning, self._updatePeriodSeconds, self._pollingCondition, conditionVariables)
+
+    def run(self, sqlalchemy_engine = None):
+        if sqlalchemy_engine:
+            self._process.set_writer(sqlalchemy_engine)
+        self._process.start()
+
+    def stop(self):
+        self._keepRunning.value = False
+        with self._pollingCondition:
+            self._pollingCondition.notify() # Wake rather than wait for the full polling time
+        self._process.join()
+
+    def updatePeriod(self):
+        """
+        Get the time in seconds that the monitor takes between updates.
+        """
+        return self._updatePeriodSeconds.value
+
+    def updatePeriod(self,time):
+        """
+        Set the time in seconds that the monitor takes between updates.
+
+        When this is called, the monitor immediately updates and then uses the new period after
+        that.
+        """
+        self._updatePeriodSeconds.value = time
+        # I'll wake the process so that it immediately starts using the new period rather than
+        # finish the current wait. This has the side effect of having an immediate update, but
+        # rather that than having it wait for the full old period in case an exceptionally long
+        # time was previously set.
+        with self._pollingCondition:
+            self._pollingCondition.notify()
+
+    def setTime(self, referenceTime, coefficient=1000):
+        """
+        Offset the times recorded in the database by specifying what the time should be right now.
+        Also allow different units by passing a value other than 1 for 'coefficient'. 'coefficient'
+        will be applied to the time in seconds to get the value that is put in the database.
+        E.g. a coefficient of 1000 will mean the time in the database will be milliseconds. A
+        coefficient of 1 will mean the time in the database is in seconds. Default is milliseconds.
+        """
+        self._process._timeOffset.value = time.time() - float(referenceTime)/float(coefficient)
+        self._process._timeCoefficient.value = coefficient
+        
+    def tableName(self):
+        """
+        Get the name of the database table results are written to
+        """
+        return self._process._tableName

--- a/src/ethoscope/hardware/input/cameras.py
+++ b/src/ethoscope/hardware/input/cameras.py
@@ -457,7 +457,7 @@ class OurPiCameraAsync(BaseCamera):
             else:
                 logging.info('Maximal effective resolution is "%s"' % str(self._resolution))
         super(OurPiCameraAsync, self).__init__(*args, **kwargs)
-        if hasattr(self._p, "analog_gain"): self._metadata["analog_gain"] = self._p._analog_gain # has to be after the super because it uses _metadata from the super class
+        if hasattr(self._p, "_analog_gain"): self._metadata["analog_gain"] = self._p._analog_gain # has to be after the super because it uses _metadata from the super class
         self._start_time = time.time()
         logging.info("Camera initialised")
 

--- a/src/ethoscope/hardware/input/cameras.py
+++ b/src/ethoscope/hardware/input/cameras.py
@@ -333,7 +333,7 @@ class V4L2Camera(BaseCamera):
 
 class PiFrameGrabber(multiprocessing.Process):
 
-    def __init__(self, target_fps, target_resolution, queue, meta_queue, stop_queue, *args, **kwargs):
+    def __init__(self, target_fps, target_resolution, queue, stop_queue, *args, **kwargs):
         """
         Class to grab frames from pi camera. Designed to be used within :class:`~ethoscope.hardware.camreras.camreras.OurPiCameraAsync`
         This allows to get frames asynchronously as acquisition is a bottleneck.
@@ -344,8 +344,6 @@ class PiFrameGrabber(multiprocessing.Process):
         :type target_resolution: (int, int)
         :param queue: a queue that stores frame and makes them available to the parent process
         :type queue: :class:`~multiprocessing.Queue`
-        :param meta_queue: a queue that communicates meta data from the camera (currently just the analogue gain)
-        :type meta_queue: :class:`~multiprocessing.Queue`
         :param stop_queue: a queue that can stop the async acquisition
         :type stop_queue: :class:`~multiprocessing.JoinableQueue`
         :param args: additional arguments
@@ -353,10 +351,10 @@ class PiFrameGrabber(multiprocessing.Process):
         """
 
         self._queue = queue
-        self._meta_queue = meta_queue
         self._stop_queue = stop_queue
         self._target_fps = target_fps
         self._target_resolution = target_resolution
+        self._analog_gain = multiprocessing.Value("f", -1.0)
         super(PiFrameGrabber, self).__init__()
 
 
@@ -396,7 +394,7 @@ class PiFrameGrabber(multiprocessing.Process):
                     #fixme here we could actually pass a JPG compressed file object (http://docs.scipy.org/doc/scipy-0.16.0/reference/generated/scipy.misc.imsave.html)
                     # This way, we would manage to get faster FPS
                     self._queue.put(out)
-                    self._meta_queue.put({"analog_gain":capture.analog_gain})
+                    self._analog_gain.value = float(capture.analog_gain)
         finally:
             logging.warning("Closing frame grabber process")
             self._stop_queue.close()
@@ -430,9 +428,8 @@ class OurPiCameraAsync(BaseCamera):
         self._args = args
         self._kwargs = kwargs
         self._queue = multiprocessing.Queue(maxsize=1)
-        self._meta_queue = multiprocessing.Queue(maxsize=1) # queue to transfer metadata
         self._stop_queue = multiprocessing.JoinableQueue(maxsize=1)
-        self._p = self._frame_grabber_class(target_fps,target_resolution,self._queue,self._meta_queue,self._stop_queue, *args, **kwargs)
+        self._p = self._frame_grabber_class(target_fps,target_resolution,self._queue,self._stop_queue, *args, **kwargs)
         self._p.daemon = True
         self._p.start()
         try:
@@ -440,12 +437,9 @@ class OurPiCameraAsync(BaseCamera):
         except Exception as e:
             logging.error("Could not get any frame from the camera")
             self._stop_queue.cancel_join_thread()
-            self._meta_queue.cancel_join_thread()
             self._queue.cancel_join_thread()
             logging.warning("Stopping stop queue")
             self._stop_queue.close()
-            logging.warning("Stopping meta data queue")
-            self._meta_queue.close()
             logging.warning("Stopping queue")
             self._queue.close()
             logging.warning("Joining process")
@@ -463,6 +457,7 @@ class OurPiCameraAsync(BaseCamera):
             else:
                 logging.info('Maximal effective resolution is "%s"' % str(self._resolution))
         super(OurPiCameraAsync, self).__init__(*args, **kwargs)
+        if hasattr(self._p, "analog_gain"): self._metadata["analog_gain"] = self._p._analog_gain # has to be after the super because it uses _metadata from the super class
         self._start_time = time.time()
         logging.info("Camera initialised")
 
@@ -500,18 +495,13 @@ class OurPiCameraAsync(BaseCamera):
     def _close(self):
         logging.info("Requesting grabbing process to stop!")
         self._stop_queue.put(None)
-        while not self._meta_queue.empty():
-             self._meta_queue.get()
         while not self._queue.empty():
              self._queue.get()
         logging.info("Joining stop queue")
         self._stop_queue.cancel_join_thread()
-        self._meta_queue.cancel_join_thread()
         self._queue.cancel_join_thread()
         logging.info("Stopping stop queue")
         self._stop_queue.close()
-        logging.info("Stopping meta data queue")
-        self._meta_queue.close()
         logging.info("Stopping queue")
         self._queue.close()
         logging.info("Joining process")
@@ -521,7 +511,6 @@ class OurPiCameraAsync(BaseCamera):
     def _next_image(self):
         try:
             g = self._queue.get(timeout=30)
-            self._metadata = self._meta_queue.get(timeout=30)
             cv2.cvtColor(g,cv2.COLOR_GRAY2BGR,self._frame)
             return self._frame
         except Exception as e:

--- a/src/ethoscope/tests/unittests/test_ConditionsMonitor.py
+++ b/src/ethoscope/tests/unittests/test_ConditionsMonitor.py
@@ -1,0 +1,81 @@
+#! /usr/bin/env python
+
+"""
+Tests for the ConditionsMonitor class
+"""
+__author__    = "Mark Grimes"
+__copyright__ = "Copyright 2017, Rymapt Ltd"
+__licence__   = "MIT"
+# MIT licence is available at https://opensource.org/licenses/MIT
+
+import unittest
+from ethoscope.core.conditions_monitor import ConditionsMonitor
+import sqlalchemy
+import time
+import random
+import os
+
+class DummyTestingConditionVariable(object):
+    """
+    Creates an array of random numbers and then returns each one in sequence for
+    each call of 'value()'. When the sequence is exhausted, it wraps around and
+    start returning the **same** numbers. You can repeat the sequence by calling
+    'reset()' and then 'value()' the required number of times.
+    """
+    def __init__(self, name="RandomNumber", size=50):
+        self._name = name
+        self._values = [0]*size
+        for index in xrange(0,size):
+            self._values[index] = random.randint(0,100)
+        self._nextIndex = 0
+    def value(self):
+        returnValue = self._values[self._nextIndex]
+        self._nextIndex = (self._nextIndex+1)%len(self._values)
+        return returnValue
+    def name(self):
+        return self._name
+    def reset(self):
+        self._nextIndex = 0
+
+class TestConditionsMonitor(unittest.TestCase):
+    def test_insertingRandomNumbers(self):
+        # In memory SQLite databases won't work because they're released before I can check
+        # the results. Use a random portion to the filename to minimise chances of a clash
+        temporaryFilename = "tmp_test_db_"+str(random.randint(0,1000))+".sqlite"
+        try:
+            variables = [DummyTestingConditionVariable("Field1"), DummyTestingConditionVariable("Field2")]
+            monitor = ConditionsMonitor(variables)
+            engine = sqlalchemy.create_engine('sqlite:///'+temporaryFilename)
+            #engine = sqlalchemy.create_engine('mysql://ethoscope:ethoscope@localhost/ethoscope_db', echo=True)
+            monitor.updatePeriod(0.01) # Update every hundredth of a second to speed up the tests
+            startTime = time.time()
+            monitor.setTime(0) # Test setting a time offset by specifying 'now' as 0 time
+            monitor.run(engine)
+            time.sleep(1)
+            monitor.stop()
+            stopTime = time.time()
+            
+            # Now check the results that were inserted
+            metadata = sqlalchemy.MetaData(engine)
+            table = sqlalchemy.Table( monitor.tableName(), metadata, autoload=True )
+            select = sqlalchemy.select([table])
+            connection = engine.connect()
+            results = connection.execute( select )
+            variables[0].reset() # Reset so that I get the same sequence of numbers
+            variables[1].reset()
+            index = 0
+            for index, row in enumerate(results):
+                self.assertEqual(row[0], index+1) # Check index increases by 1 each time
+                self.assertGreaterEqual(row[1], 0) # Check time is greater than the reference time I set (zero)
+                self.assertLessEqual(row[1], (stopTime-startTime)*1000) # default is to store time in milliseconds
+                self.assertEqual(row[2], variables[0].value())
+                self.assertEqual(row[3], variables[1].value())
+            self.assertGreaterEqual(index, 10) # Make sure at least some records were created
+        finally:
+            try:
+                os.remove(temporaryFilename)
+            except OSError:
+                pass # probably was never created, let the original exception show through
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ethoscope/tests/unittests/test_ConditionsMonitor.py
+++ b/src/ethoscope/tests/unittests/test_ConditionsMonitor.py
@@ -50,7 +50,7 @@ class TestConditionsMonitor(unittest.TestCase):
             monitor.updatePeriod(0.01) # Update every hundredth of a second to speed up the tests
             startTime = time.time()
             monitor.setTime(0) # Test setting a time offset by specifying 'now' as 0 time
-            monitor.run(engine)
+            monitor.run(sqlalchemy_engine=engine)
             time.sleep(1)
             monitor.stop()
             stopTime = time.time()

--- a/src/ethoscope/tests/unittests/test_HIH6130.py
+++ b/src/ethoscope/tests/unittests/test_HIH6130.py
@@ -10,8 +10,9 @@ __license__   = "MIT"
 # MIT licence is available at https://opensource.org/licenses/MIT
 
 import unittest
+import time
 import ethoscope.hardware.input.easyi2c as easyi2c
-from ethoscope.hardware.input.HIH6130 import HIH6130
+from ethoscope.hardware.input.HIH6130 import HIH6130, BufferedHIH6130
 
 class TestHIH6130(unittest.TestCase):
     def test_constructWitheasyi2c(self):
@@ -37,6 +38,54 @@ class TestHIH6130(unittest.TestCase):
         # this range the chip probably won't work anyway.
         self.assertGreaterEqual(data[2], -25)
         self.assertLessEqual(data[2], 85)
+
+class TestBufferedHIH6130(unittest.TestCase):
+    def test_constructWitheasyi2c(self):
+        DEVICE_ADDRESS= 0x27 #For temperature sensor
+        easybus= easyi2c.IIC(DEVICE_ADDRESS, 1)
+        myHIH = BufferedHIH6130(easybus)
+        self.performTests(myHIH)
+
+    def test_constructAutomatically(self):
+        myHIH = BufferedHIH6130()
+        self.performTests(myHIH)
+
+    def test_update(self):
+        # Set the update time really low, to make sure that the values do
+        # actually update. To check that an update actually occurs, need to
+        # reach inside the class and put invalid values in the buffered data.
+        myHIH = BufferedHIH6130(updateTime=0.05)
+        oldData = myHIH.getData()
+        myHIH._data = [-1,-1,1000] # Invalidate the buffer
+        time.sleep(0.1) # Sleep long enough for data to be stale
+        self.performTests(myHIH)
+        data = myHIH.getData()
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data[0], 0)
+        self.assertGreaterEqual(data[1], 0)
+        self.assertLessEqual(data[1], 100)
+        self.assertGreaterEqual(data[2], -25)
+        self.assertLessEqual(data[2], 85)
+
+    def performTests(self, device):
+        # This should run fast enough that all of these calls return the same
+        # buffered values.
+        data1 = device.getData()
+        data2 = device.getData()
+        self.assertEqual( data1, data2 )
+        humidity = device.humidity()
+        temp = device.temperature()
+        self.assertEqual( data1[1], humidity )
+        self.assertEqual( data1[2], temp )
+
+        # Test the relative humidity.
+        self.assertGreaterEqual(humidity, 0)
+        self.assertLessEqual(humidity, 100)
+        # Test the temperature. These temperatures are taken from the documented
+        # operating temperature, so if you're testing when the temperature is outside
+        # this range the chip probably won't work anyway.
+        self.assertGreaterEqual(temp, -25)
+        self.assertLessEqual(temp, 85)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/ethoscope/tests/unittests/test_HIH6130.py
+++ b/src/ethoscope/tests/unittests/test_HIH6130.py
@@ -35,8 +35,8 @@ class TestHIH6130(unittest.TestCase):
         # Test the temperature. These temperatures are taken from the documented
         # operating temperature, so if you're testing when the temperature is outside
         # this range the chip probably won't work anyway.
-        self.assertGreaterEqual(data[1], -25)
-        self.assertLessEqual(data[1], 85)
+        self.assertGreaterEqual(data[2], -25)
+        self.assertLessEqual(data[2], 85)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/ethoscope/tests/unittests/test_HIH6130.py
+++ b/src/ethoscope/tests/unittests/test_HIH6130.py
@@ -13,7 +13,7 @@ import unittest
 import ethoscope.hardware.input.easyi2c as easyi2c
 from ethoscope.hardware.input.HIH6130 import HIH6130
 
-class TestTargetROIBuilder(unittest.TestCase):
+class TestHIH6130(unittest.TestCase):
     def test_constructWitheasyi2c(self):
         DEVICE_ADDRESS= 0x27 #For temperature sensor
         easybus= easyi2c.IIC(DEVICE_ADDRESS, 1)

--- a/src/ethoscope/web_utils/control_thread.py
+++ b/src/ethoscope/web_utils/control_thread.py
@@ -14,6 +14,7 @@ from ethoscope.hardware.input.cameras import OurPiCameraAsync, MovieVirtualCamer
 from ethoscope.roi_builders.target_roi_builder import  OlfactionAssayROIBuilder, SleepMonitorWithTargetROIBuilder, TargetGridROIBuilder
 from ethoscope.roi_builders.roi_builders import  DefaultROIBuilder
 from ethoscope.core.monitor import Monitor
+from ethoscope.core.conditions_monitor import ConditionsMonitor, ConditionVariable
 from ethoscope.drawers.drawers import NullDrawer, DefaultDrawer
 from ethoscope.trackers.adaptive_bg_tracker import AdaptiveBGModel
 from ethoscope.hardware.interfaces.interfaces import HardwareConnection
@@ -171,6 +172,7 @@ class ControlThread(Thread):
                         "experimental_info": {}
                         }
         self._monit = None
+        self._conditionsMonitor = None
 
         self._parse_user_options(data)
 
@@ -303,10 +305,25 @@ class ControlThread(Thread):
         self._monit = Monitor(camera, TrackerClass, rois,
                               stimulators=stimulators,
                               *self._monit_args)
+
+        conditionVariables = []
+        try:
+            variable = camera.metadata("analog_gain") # This might fail depending on the type of camera
+            conditionVariables.append( ConditionVariable(variable, "camera_gain") )
+        except KeyError as error:
+            # analog_gain is not part of the meta data for this camera
+            logging.warning("Unable to get the camera gain to add to the condition database")
+        self._conditionsMonitor = ConditionsMonitor( conditionVariables )
+        dbConnectionString = "mysql://"+self._db_credentials["user"]+":"+self._db_credentials["password"]+"@localhost/"+self._db_credentials["name"]
+
         self._info["status"] = "running"
         logging.info("Setting monitor status as running: '%s'" % self._info["status"])
 
-        self._monit.run(result_writer, self._drawer)
+        # Align the times in the database tables as closely as possible. The conditions monitor only updates
+        # every 30 seconds by default, so some small difference is acceptable.
+        self._conditionsMonitor.setTime(0)
+        self._conditionsMonitor.run(dbConnectionString) # This runs asynchronously
+        self._monit.run(result_writer, self._drawer) # This blocks
 
     def _set_tracking_from_pickled(self):
         with open(self._persistent_state_file, "r") as f:
@@ -462,6 +479,10 @@ class ControlThread(Thread):
         if not self._monit is None:
             self._monit.stop()
             self._monit = None
+        logging.info("Stopping conditions monitor")
+        if not self._conditionsMonitor is None:
+            self._conditionsMonitor.stop()
+            self._conditionsMonitor = None
 
         self._info["status"] = "stopped"
         self._info["time"] = time.time()

--- a/src/ethoscope/web_utils/control_thread.py
+++ b/src/ethoscope/web_utils/control_thread.py
@@ -14,10 +14,11 @@ from ethoscope.hardware.input.cameras import OurPiCameraAsync, MovieVirtualCamer
 from ethoscope.roi_builders.target_roi_builder import  OlfactionAssayROIBuilder, SleepMonitorWithTargetROIBuilder, TargetGridROIBuilder
 from ethoscope.roi_builders.roi_builders import  DefaultROIBuilder
 from ethoscope.core.monitor import Monitor
-from ethoscope.core.conditions_monitor import ConditionsMonitor, ConditionVariable
+from ethoscope.core.conditions_monitor import ConditionsMonitor, ConditionVariable, ConditionVariableFunction
 from ethoscope.drawers.drawers import NullDrawer, DefaultDrawer
 from ethoscope.trackers.adaptive_bg_tracker import AdaptiveBGModel
 from ethoscope.hardware.interfaces.interfaces import HardwareConnection
+from ethoscope.hardware.input.HIH6130 import BufferedHIH6130
 from ethoscope.stimulators.stimulators import DefaultStimulator
 #<<<<<<< HEAD
 #from ethoscope.stimulators.sleep_depriver_stimulators import , SleepDepStimulator, SleepDepStimulatorCR, ExperimentalSleepDepStimulator, MiddleCrossingStimulator#, SystematicSleepDepInteractor
@@ -313,6 +314,12 @@ class ControlThread(Thread):
         except KeyError as error:
             # analog_gain is not part of the meta data for this camera
             logging.warning("Unable to get the camera gain to add to the condition database")
+        try:
+            sensorChip = BufferedHIH6130()
+            conditionVariables.append( ConditionVariableFunction(sensorChip.humidity, "humidity") )
+            conditionVariables.append( ConditionVariableFunction(sensorChip.temperature, "temperature") )
+        except Exception as error:
+            logging.warning("Unable to get the temperature or humidity sensor to add to the conditions database because: "+str(error))
         self._conditionsMonitor = ConditionsMonitor( conditionVariables )
         dbConnectionString = "mysql://"+self._db_credentials["user"]+":"+self._db_credentials["password"]+"@localhost/"+self._db_credentials["name"]
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -33,7 +33,8 @@ setup(
     install_requires=[
         "numpy>=1.6.1",
         "scipy >= 0.15.1",
-        "zeroconf>=0.19.1"
+        "zeroconf>=0.19.1",
+        "SQLAlchemy"
     ],
     tests_require=['nose', 'mock'],
     test_suite='nose.collector'


### PR DESCRIPTION
Add a conditions monitor that writes to the database table "CONDITIONS" every 30 seconds while running.  Variables added are:
* time in milliseconds, with the start of the run ~zero (to match the tracking data)
* the camera analogue gain - a float ranging from 1 (high light conditions) to 8 (low light conditions)
* the temperature from the HIH6130 chip (if available)
* the humidity from the HIH6130 chip (if available)

There are also some tests in `ethoscope/tests/unittests/test_ConditionsMonitor`.

Here's what the database looks like after running for about 5 minutes in daylight, covering the device with a jumper half way through, and putting my finger on the HIH6130 sensor near the end:

![conditionsdatabase](https://user-images.githubusercontent.com/6480160/28216078-24e50970-68a8-11e7-8740-93c3fb0e480a.png)
