### PR TITLE
Add SQLite download

### DIFF
--- a/node_src/ethoscope_node/tests/unittests/test_mysql_db_converter.py
+++ b/node_src/ethoscope_node/tests/unittests/test_mysql_db_converter.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python
+
+"""
+Tests for the MySQLdbConverter class.
+"""
+__author__    = "Mark Grimes"
+__copyright__ = "Copyright 2017, Rymapt Ltd"
+__license__   = "MIT"
+# MIT licence is available at https://opensource.org/licenses/MIT
+# Note that the ethoscope software is GPL 3, so when included in that source tree this file becomes GPL 3. By
+# being licensed as MIT enables this file (and this alone) to be used in other projects under the MIT licence.
+
+import unittest
+from ethoscope_node.utils.mysql_db_converter import MySQLdbConverter
+import os
+import logging
+
+
+class TestMySQLCSVWriter(unittest.TestCase):
+    def test_MySQLConvertToSQLite(self):
+        """
+        This is a rubbish test. So far all I'm testing is that it doesn't crash when trying to access the ethoscope
+        device's database. It doesn't even set that up, it needs the database to be already running.
+        
+        TODO - Write some decent tests with well known inputs. Probably have an SQLite file in the repository as test
+        data.
+        """
+
+        root_dir = os.path.dirname(os.path.abspath(__file__)) # where all the test paths are relative to
+
+        converter = MySQLdbConverter()
+        converter.copy_database("sqlite:////"+root_dir+"/testDump.sqlite3")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node_src/ethoscope_node/utils/mysql_db_converter.py
+++ b/node_src/ethoscope_node/utils/mysql_db_converter.py
@@ -1,0 +1,112 @@
+"""
+Class for using SQLAlchemy (http://www.sqlalchemy.org/) for converting from the MySQL database
+to different database types.
+"""
+__author__    = "Mark Grimes"
+__copyright__ = "Copyright 2017, Rymapt Ltd"
+__license__   = "MIT"
+# MIT licence is available at https://opensource.org/licenses/MIT
+# Note that the ethoscope software is GPL 3, so when included in that source tree this file becomes GPL 3. By
+# being licensed as MIT enables this file (and this alone) to be used in other projects under the MIT licence.
+
+import logging
+import sqlalchemy
+import sqlalchemy.ext.compiler
+import sqlalchemy.dialects.mysql
+
+# Define the custom mappings from MySQL to SQLite that aren't covered by the defaults
+@sqlalchemy.ext.compiler.compiles(sqlalchemy.dialects.mysql.TINYINT, 'sqlite')
+def compile_TINYINT(element, compiler, **kw):
+    """Treat MySQL TINYINT as normal integer in SQLite"""
+    return compiler.visit_integer(element, **kw)
+
+@sqlalchemy.ext.compiler.compiles(sqlalchemy.dialects.mysql.LONGBLOB, 'sqlite')
+def compile_LONGBLOB(element, compiler, **kw):
+    """Treat MySQL LONGBLOB as large binary in SQLite"""
+    return compiler.visit_large_binary(element, **kw)
+
+class MySQLdbConverter(object):
+    """
+    This class can be used to convert the MySQL database to any format supported by SQLAlchemy. It's used for the SQLite
+    download functionality. Note that the class MySQLdbToSQlite in mysql_backup.py does something similar except that it
+    is selective about which data it converts to the SQLite file. This class just copies all data verbatim which has the
+    advantage of including conditions data and anything added by later development, but the down side of including lots
+    of data.
+    """
+
+    def __init__(self,
+                            remote_db_name="ethoscope_db",
+                            remote_host="localhost",
+                            remote_user="ethoscope",
+                            remote_pass="ethoscope",
+                            input_engine=None,
+                            input_address=None
+                            ):
+        """
+        :param remote_db_name: the name of the database running locally.
+        :param remote_host: the ip of the database - localhost will be fully test remote testing to follow
+        :param remote_user: the user name for the database
+        :param remote_pass: the password for the database
+        :param input_engine: an SQLAlchemy engine for the input database. If supplied then remote_db_name,
+                             remote_host, remote_user and remote_pass are silently ignored. If input_address
+                             is specified that is ignored (i.e. input_engine takes precedence).
+        :param input_address: an SQLAlchemy location of the input database. If supplied then remote_db_name,
+                              remote_host, remote_user and remote_pass are silently ignored.
+        """
+
+        if input_engine:
+            if input_address!= None : logging.warning("MySQLdbConverter: An SQLAlchemy engine was provided, so the value of input_address is being ignored")
+            self._input_engine = input_engine
+        elif input_address:
+            self._input_engine = sqlalchemy.create_engine(connection_address)
+        else:
+            self._input_engine = sqlalchemy.create_engine("mysql://"+remote_user+":"+remote_pass+"@"+remote_host+"/"+remote_db_name)
+
+        self._batchSize = 200 # The number of inserts to group so that copying is faster
+
+    def copy_database(self, connection_address=None, sqlalchemy_engine = None):
+        """
+        Copy the database to a new database at the location provided. The strings are in the format required by sqlalchemy e.g.
+
+            "sqlite:///myfile.sqlite3" - SQLite file at the location ./myfile.sqlite3 (note 3 backslashes)
+            "sqlite:////tmp/myfile.sqlite3" - SQLite file at the location /tmp/myfile.sqlite3 (note 4 backslashes)
+
+        You can also instead provide an sqlalchemy engine directly with the sqlalchemy_engine keyword parameter. For a full list
+        of possible strings, and how to configure your own engine, see
+
+            http://docs.sqlalchemy.org/en/latest/core/engines.html
+
+        This function is highly likely to fail if the file already exists.
+        """
+        if sqlalchemy_engine:
+            if connection_address!= None : logging.warning("MySQLdbConverter: An SQLAlchemy engine was provided, so the value of connection_address is being ignored")
+        elif connection_address:
+            sqlalchemy_engine = sqlalchemy.create_engine(connection_address)
+        else:
+            raise Exception("MySQLdbConverter.copy_database() called without a connection address or SQLAlchemy engine")
+        
+        inputMetadata = sqlalchemy.MetaData(bind=self._input_engine)
+        inputMetadata.reflect(self._input_engine)
+        outputMetadata = sqlalchemy.MetaData(bind=sqlalchemy_engine)
+    
+        for tableName, inputTable in inputMetadata.tables.iteritems():
+            #
+            # First copy the schema for the table
+            #
+            outputTable = sqlalchemy.Table(inputTable.name, outputMetadata)
+            for inputColumn in inputTable.columns:
+                outputTable.append_column(inputColumn.copy())
+            outputTable.create()
+            #
+            # Then copy the data
+            #
+            insert = outputTable.insert()
+            # Group the inserts into the destination into batches to speed up the copy.
+            bulkRows = []
+            for row in inputTable.select().execute():
+                bulkRows.append(row)
+                if len(bulkRows) > self._batchSize :
+                    insert.execute(bulkRows)
+                    bulkRows = []
+            if len(bulkRows) > 0 :
+                insert.execute(bulkRows)

--- a/node_src/scripts/server.py
+++ b/node_src/scripts/server.py
@@ -6,6 +6,7 @@ import traceback
 from ethoscope_node.utils.helpers import  get_local_ip, get_internet_ip
 from ethoscope_node.utils.device_scanner import DeviceScanner
 from ethoscope_node.utils.mysql_db_writer import MySQLdbCSVWriter
+from ethoscope_node.utils.mysql_db_converter import MySQLdbConverter
 from os import walk
 import optparse
 import zipfile
@@ -281,13 +282,29 @@ def redirection_to_home(id):
 
 @app.get('/downloaddb/<id>')
 def dynamic_serve_db(id):
-    response.headers["Content-Disposition"]="attachment; filename=ethoscope_db.txt"
-    try:
-        remote_host=request.query["ip"]
-    except:
-        remote_host="localhost"
-    converter = MySQLdbCSVWriter( remote_host=remote_host)
-    return converter.enumerate_roi_tables()
+    try:    remote_host=request.query["ip"]
+    except: remote_host="localhost"
+
+    try:    format=request.query["format"]
+    except: format="tab"
+
+    if format=="tab":
+        response.headers["Content-Disposition"]="attachment; filename=ethoscope_db.txt"
+        converter = MySQLdbCSVWriter( remote_host=remote_host )
+        return converter.enumerate_roi_tables()
+    elif format=="sqlite":
+        # Usually doesn't work if the file already exists
+        temporaryFilename = "/dev/shm/ethoscope_db.sqlite"
+        try:
+            os.remove(temporaryFilename)
+        except:
+            pass
+
+        converter = MySQLdbConverter( remote_host=remote_host )
+        converter.copy_database("sqlite:////"+temporaryFilename)
+        return static_file(temporaryFilename, root="/", download="ethoscope_db.sqlite")
+    else:
+        raise Exception("The format '"+format+"' is not known")
 
 @app.get('/device/<id>/ip')
 @error_decorator

--- a/node_src/scripts/server.py
+++ b/node_src/scripts/server.py
@@ -292,7 +292,10 @@ def dynamic_serve_db(id):
         response.headers["Content-Disposition"]="attachment; filename=ethoscope_db.txt"
         converter = MySQLdbCSVWriter( remote_host=remote_host )
         return converter.enumerate_roi_tables()
-    elif format=="sqlite":
+    elif format=="sqlite" or format=="sqlite-slim":
+        if format=="sqlite": skip_tables=None
+        else: skip_tables=["IMG_SNAPSHOTS"]
+
         # Usually doesn't work if the file already exists
         temporaryFilename = "/dev/shm/ethoscope_db.sqlite"
         try:
@@ -301,7 +304,7 @@ def dynamic_serve_db(id):
             pass
 
         converter = MySQLdbConverter( remote_host=remote_host )
-        converter.copy_database("sqlite:////"+temporaryFilename)
+        converter.copy_database("sqlite:////"+temporaryFilename, skip_tables=skip_tables)
         return static_file(temporaryFilename, root="/", download="ethoscope_db.sqlite")
     else:
         raise Exception("The format '"+format+"' is not known")

--- a/node_src/static/js/controllers/ethoscopeController.js
+++ b/node_src/static/js/controllers/ethoscopeController.js
@@ -170,10 +170,19 @@ app.controller('ethoscopeController', function($scope, $http, $routeParams, $int
             $http.get($scope.device.ip+':9000/static'+$scope.result_files);
         };
 
-        $scope.ethoscope.downloaddb = function(){
+        $scope.ethoscope.downloaddb = function(format){
+            // Can't figure out how to do this querySelector on the HTML side, so do it
+            // here instead. I'd prefer to not have to know the input name at this point.
+            try{
+                if( format==undefined ) format=document.querySelector('input[name="download_format"]:checked').value;
+            }
+            catch(error){
+                console.error("Unable to get the format for the database download",error);
+            }
+
             var downloadLink=$("#downloaddbHiddenLink")
             downloadLink.attr({
-                href: "/downloaddb/"+device_id+"?ip="+$scope.device.ip,
+                href: "/downloaddb/"+device_id+"?ip="+$scope.device.ip + (format!=undefined ? "&format="+format : ""),
                 target: "_blank"
                 })
             downloadLink[0].click();

--- a/node_src/static/pages/ethoscope.html
+++ b/node_src/static/pages/ethoscope.html
@@ -142,7 +142,8 @@
       </div>
       <div class="modal-body">
         <input type="radio" name="download_format" value="tab"/>As tab separated values (doesn't include conditions data)<br/>
-        <input type="radio" name="download_format" value="sqlite" checked/>As SQLite3 file<br/>
+        <input type="radio" name="download_format" value="sqlite"/>Full database as SQLite3 file<br/>
+        <input type="radio" name="download_format" value="sqlite-slim" checked/>As SQLite3 file but without image snapshots (considerably smaller files)<br/>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/node_src/static/pages/ethoscope.html
+++ b/node_src/static/pages/ethoscope.html
@@ -141,7 +141,8 @@
         <h4 class="modal-title" id="downloadResultsModalLabel">Download results</h4>
       </div>
       <div class="modal-body">
-        Download the results database as tab separated values.
+        <input type="radio" name="download_format" value="tab"/>As tab separated values (doesn't include conditions data)<br/>
+        <input type="radio" name="download_format" value="sqlite" checked/>As SQLite3 file<br/>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
Currently the option to download results as tab separated data doesn't include any conditions data.  This pull request adds a radio button selection to the download modal to select either tab separated data or an SQLite file.

I didn't use the existing classes for converting from MySQL to SQLite (as used in the database backup service that runs on the stand alone node) because that selectively copies data, and hence doesn't include the conditions either.  I used the SQLAlchemy library to do all of the heavy lifting and copy whatever is in the database.  This means any extra tables added by further development will also be included.  It does have the downside of creating much larger files though, because even the image snapshots are currently saved.  If that gets to be a problem we could include an option to skip certain tables.

There is a script with tests but it's currently awful.  I need to create some dummy data files so that we can write some proper tests.

If you apply this pull request to a running device, only the ethoscope_node service needs to be restarted.
