### PR TITLE
Add watchdog (aka heartbeat) to the node service

### DIFF
--- a/node_src/setup.py
+++ b/node_src/setup.py
@@ -27,6 +27,7 @@ setup(
         "GitPython >=1.0.1",
         "bjoern >= 1.4.2",
         "scapy == 2.3.2",
-        "zeroconf>=0.19.1"
+        "zeroconf >= 0.19.1",
+        "sdnotify >= 0.3.2"
     ],
 )

--- a/scripts/ethoscope_node.service
+++ b/scripts/ethoscope_node.service
@@ -10,6 +10,7 @@ WorkingDirectory=/opt/ethoscope-git/node_src/scripts
 ExecStart=/usr/bin/python2  /opt/ethoscope-git/node_src/scripts/server.py
 RestartSec=5
 Restart=always
+WatchdogSec=40
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Changes the systemd settings so that the node service is restarted if systemd doesn't get a notification every 40 seconds.  Inside the service this notification is only sent if a separate thread is able to get the main webpage.

So if the node service goes down for any reason, it stops reporting to systemd which should restart the service after 40 seconds.

The change in the software should be transparent if systemd is not expecting the notifications, i.e. if running outside systemd, or without the watchdog setting, then there is no difference (apart from one warning message to say that no watchdog has started).