### PR TITLE
Downgrade scipy version

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -32,7 +32,7 @@ setup(
         ],
     install_requires=[
         "numpy>=1.6.1",
-        "scipy >= 0.15.1",
+        "scipy >= 0.14.0",
         "zeroconf>=0.19.1",
         "SQLAlchemy"
     ],


### PR DESCRIPTION
On Raspbian, the version of scipy used (i.e. the one installed by `apt-get`) is v0.14.0.  The ethoscope software currently "requires" v0.15.1.  This causes the build process to avoid the installed version, and download and compile from source (in *one thread*!) which takes somewhere in the region of four hours.  I asked Quentin and he said the version number was only chosen because that was the version he had installed by whatever distro they use.

Looking into it, the ethoscope device software uses just the function `scipy.ndimage.measurements.center_of_mass` from scipy.  There is no change to this code when going from v0.14.0 to v0.15.1 ([git diff](https://github.com/scipy/scipy/compare/v0.14.0...v0.15.1#diff-579de2d8d7291d757845bb3d708c329a), then go to "Files" and search for `scipy/ndimage/measurements.py`).

It's actually a fairly simple bit of code. I'm tempted to copy and paste it somewhere so that we can avoid a dependency on scipy altogether (which is BIG).