### PR TITLE
Fix SMBus dependency

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -34,7 +34,8 @@ setup(
         "numpy>=1.6.1",
         "scipy >= 0.14.0",
         "zeroconf>=0.19.1",
-        "SQLAlchemy"
+        "SQLAlchemy",
+        "smbus"
     ],
     tests_require=['nose', 'mock'],
     test_suite='nose.collector'


### PR DESCRIPTION
Pull request #51 added support for the TSL2591 light sensor, but it imports `smbus`. This isn't installed by default so will break an install on a fresh system. This PR just adds `smbus` as a dependency