### PR TITLE
Make the zeroconf handling more robust

### DIFF
--- a/src/scripts/device_server.py
+++ b/src/scripts/device_server.py
@@ -256,12 +256,18 @@ if __name__ == '__main__':
         run(api, host='0.0.0.0', port=port, debug=option_dict["debug"])
     except Exception as e:
         logging.error(e)
-        zeroconf.unregister_service(serviceInfo)
-        zeroconf.close()
+        try:
+            zeroconf.unregister_service(serviceInfo)
+            zeroconf.close()
+        except:
+            pass
         close(1)
     finally:
-        zeroconf.unregister_service(serviceInfo)
-        zeroconf.close()
+        try:
+            zeroconf.unregister_service(serviceInfo)
+            zeroconf.close()
+        except:
+            pass
         close()
 
 


### PR DESCRIPTION
Zeroconf seems to mess up in the node on first boot.  The node works fine if you restart the service, but gets into a state after booting where the devices aren't registered properly (`zeroconf.get_service_info(type, name)` returns `None` for some reason). This means no devices are listed by the node.
