### PR TITLE
Add DQM link

### DIFF
--- a/node_src/static/pages/ethoscope.html
+++ b/node_src/static/pages/ethoscope.html
@@ -73,6 +73,7 @@
             <button class="btn btn-info disable" ng-if="device.status == 'stopping'" ng-click="ethoscope.alert('Please wait, system is stopping')">Stopping</button>
             <button class="btn btn-danger disable" ng-if="device.status == 'initialising'"  ng-click="ethoscope.alert('Please wait, system is starting')">Starting</button>
 
+            <a ng-href="http://{{device.name}}.local:8081" target="_blank" class="btn btn-info">DQM</a>
             <button class="btn btn-info" data-toggle="modal" data-target="#downloadResultsModal">Download results</button>
         <!--<a href="/#/more/browse" class="btn btn-info">Download Data</a>-->
             <button class="btn btn-info" ng-click="ethoscope.log()">Log</button>


### PR DESCRIPTION
Adds a link to the DQM plots from the main ethoscope control page.
I'd prefer to somehow use `window.location` so that the protocol ("http://") and hostname (someone might prefer IP addresses if name resolution is not working) are not hard coded, but I couldn't get it to work.

This will do for now though.