### PR TITLE
Use simple string to set vibration times

### DIFF
--- a/src/ethoscope/stimulators/vibration_motor_stimulator.py
+++ b/src/ethoscope/stimulators/vibration_motor_stimulator.py
@@ -18,7 +18,7 @@ class VibrationMotorStimulator(BaseStimulator):
     _HardwareInterfaceClass = VibrationMotorInterface
 
     def __init__(self, hardware_connection=None, dates = "", **kwargs):
-        self._vibration_time = [0.2,0.2,0.2,0.2,0.2]
+        self._vibration_time = [0.4,0.2,0.4,0.2,0.4]
 
         self._times = []
         for date in dates.split(","):

--- a/src/ethoscope/stimulators/vibration_motor_stimulator.py
+++ b/src/ethoscope/stimulators/vibration_motor_stimulator.py
@@ -9,7 +9,8 @@ class VibrationMotorStimulator(BaseStimulator):
     """
     _description = {"overview": "A stimulator to vibrate the whole arena",
                     "arguments": [
-                                    {"type": "datetime", "name": "dates",
+                                    {"type": "str",
+                                     "name": "dates",
                                      "description": "A comma separated list of times to vibrate at, in the form 'YYYY-MM-DD HH:MM:SS', e.g. '2017-09-15 17:30:00, 2017-09-15 21:00:00'",
                                      "default": ""}
                                    ]}


### PR DESCRIPTION
The calendar time picker is really buggy, so switch to simple strings to set the time for the vibration motor to go off.  It's not ideal but it's the most flexible option for now.

Also changed the buzz time to be slightly longer, just to make sure those flies don't sleep through.