### PR TITLE
Enable and fix custom roi builder

### DIFF
--- a/src/ethoscope/roi_builders/target_roi_builder.py
+++ b/src/ethoscope/roi_builders/target_roi_builder.py
@@ -45,7 +45,7 @@ class TargetGridROIBuilder(BaseROIBuilder):
                                     {"type": "number", "min": 0.0, "max": 1.0, "step":.001, "name": "right_margin", "description": "Same as top_margin, but for the right.","default":0.0},
                                     {"type": "number", "min": 0.0, "max": 1.0, "step":.001, "name": "left_margin", "description": "Same as top_margin, but for the left.","default":0.0},
                                     {"type": "number", "min": 0.0, "max": 1.0, "step":.001, "name": "horizontal_fill", "description": "The proportion of the grid space user by the roi, horizontally.","default":0.90},
-                                    {"type": "number", "min": 0.0, "max": 1.0, "step":.001, "name": "left_margin", "description": "Same as horizontal_margin, but vertically.","default":0.90}
+                                    {"type": "number", "min": 0.0, "max": 1.0, "step":.001, "name": "vertical_fill", "description": "Same as horizontal_margin, but vertically.","default":0.90}
                                    ]}
     def __init__(self, n_rows=1, n_cols=1, top_margin=0, bottom_margin=0,
                  left_margin=0, right_margin=0, horizontal_fill=.9, vertical_fill=.9):

--- a/src/ethoscope/web_utils/control_thread.py
+++ b/src/ethoscope/web_utils/control_thread.py
@@ -73,7 +73,7 @@ class ControlThread(Thread):
     _evanescent = False
     _option_dict = {
         "roi_builder":{
-                "possible_classes":[DefaultROIBuilder, SleepMonitorWithTargetROIBuilder],#, TargetGridROIBuilder, OlfactionAssayROIBuilder],
+                "possible_classes":[DefaultROIBuilder, SleepMonitorWithTargetROIBuilder, TargetGridROIBuilder, OlfactionAssayROIBuilder],
             },
         "tracker":{
                 "possible_classes":[AdaptiveBGModel],


### PR DESCRIPTION
The custom RoI builder TargetGridROIBuilder has a bug where the `vertical_fill` option is accidentally labelled `left_margin`. This stops it working with a weird error about region being outside of the image.

This RoI builder is currently disabled in Rymapt devices though because we hadn't tested it. This PR also re-enables it.